### PR TITLE
fix: resolve VitePress dead-link build errors

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -16,7 +16,32 @@ export default defineConfig({
   },
 
   lastUpdated: true,
-  ignoreDeadLinks: true,
+  ignoreDeadLinks: [
+    // Skill-specific pages that don't exist in upstream docs
+    '/use/mcp',
+    '/use/knowledge-base',
+    '/use/websearch',
+    '/use/astrbot-agent-sandbox',
+    '/use/skills',
+    '/use/agent-runner',
+    '/deploy/astrbot/docker',
+    '/deploy/astrbot/kubernetes',
+    '/deploy/astrbot/launcher',
+    '/deploy/astrbot/rainyun',
+    '/platform/qqofficial/webhook',
+    '/platform/qqofficial/websockets',
+    '/dev/star/plugin',
+    '/providers/agent-runners/astrbot-agent-runner',
+    '/providers/agent-runners/dify',
+    '/providers/agent-runners/coze',
+    '/providers/agent-runners/dashscope',
+    '/providers/agent-runners/deerflow',
+    '/providers/start',
+    // Relative links in provider pages
+    './../agent-runners/coze',
+    './../agent-runners/dashscope',
+    './../agent-runners/dify',
+  ],
 
   locales: {
     root: {


### PR DESCRIPTION
## 修复内容

修复 VitePress 构建时的死链错误。

### 问题
上游 AstrBot 文档同步后，有 38 个死链导致构建失败：
- Skill 专属页面链接（如 /use/mcp, /use/knowledge-base 等）
- 相对路径链接（如 ./../agent-runners/coze）
- 缺失的部署文档链接

### 解决方案
将 ignoreDeadLinks 从 	rue 改为数组形式，明确列出需要忽略的死链路径。

### 验证
- ✅ 本地 VitePress 构建成功
- 构建时间：21.02s