### PR TITLE
docs: Add lifecycle template and async I/O best practices

### DIFF
--- a/skill-astrbot-dev/design_standards/best_practices.md
+++ b/skill-astrbot-dev/design_standards/best_practices.md
@@ -2,42 +2,68 @@
 category: design_standards
 ---
 
-# AI 插件开发最佳实践
+# AI Plugin Development Best Practices
 
-为了确保插件的稳定性、安全性和易用性，建议遵循以下实践方案。
+To ensure plugin stability, security and usability, follow these practices.
 
-### 1. 异常处理
+### 1. Exception Handling
 
-务必捕获可能的异常，并给用户明确的反馈。
+Always catch exceptions and give users clear feedback.
 
 ```python
 try:
-    # 逻辑代码
+    # logic code
 except TimeoutError:
-    yield event.plain_result("⌛ 会话已超时，请重新开始。")
+    yield event.plain_result("⌛ Session timed out, please restart.")
 except Exception as e:
-    logger.error(f"插件执行出错: {e}")
-    yield event.plain_result(f"❌ 发生错误: {e}")
+    logger.error(f"Plugin execution error: {e}")
+    yield event.plain_result(f"❌ Error: {e}")
 finally:
-    event.stop_event() # 已经处理过错误，通常建议停止事件继续传播
+    event.stop_event()
 ```
 
-### 2. 平台差异化
+### 2. Platform Differences
 
-虽然 AstrBot 提供了统一模型，但在调用底层 SDK 功能（如 `call_action`）时，需进行环境检查：
+Although AstrBot provides a unified model, check the environment when calling platform-specific SDK functionality (e.g., `call_action`):
 
 ```python
 if event.get_platform_name() == "aiocqhttp":
-    # 调用 OneBot 特有 API
+    # Call OneBot-specific API
     pass
 ```
 
-### 3. 工具 (Tools) 开发
+### 3. Tools Development
 
-- 推荐使用 `agent-as-tool` 模式。
-- 完善 Docstring，这直接决定了大模型对工具的理解能力。
-- 尽量保持工具功能的单一性。
+- Prefer the `agent-as-tool` pattern.
+- Write thorough docstrings — they directly determine how well the LLM understands the tool.
+- Keep tools single-purpose.
 
-### 4. 资源清理
+### 4. Resource Cleanup
 
-在插件卸载时，应在 `terminate()` 方法中清理定时器、数据库连接或文件句柄。
+Always clean up timers, database connections, file handles and network sessions in `terminate()`. See the full lifecycle template at `templates/plugin/main.py` for a complete implementation example.
+
+### 5. Async I/O & Thread Pool
+
+AstrBot runs on Python's asyncio event loop. Never use synchronous blocking operations inside a plugin.
+
+```python
+# ✅ Good: use async libraries
+import aiohttp
+async with aiohttp.ClientSession() as session:
+    async with session.get("https://api.example.com") as resp:
+        data = await resp.read()
+
+# ❌ Bad: synchronous calls block the entire bot event loop
+# import requests
+# data = requests.get("https://api.example.com").content  # never do this!
+
+# ✅ Fallback: if a sync library is unavoidable, use a thread pool
+import concurrent.futures
+_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+async def process_file(self, path: str):
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_executor, self._sync_read, path)
+```
+
+> **Important**: Any synchronous `time.sleep()` or `requests.get()` call will freeze the entire bot. Always use `asyncio.sleep()` and async HTTP libraries like `aiohttp` or `httpx`.

--- a/templates/plugin/main.py
+++ b/templates/plugin/main.py
@@ -1,0 +1,93 @@
+"""AstrBot Plugin Lifecycle Template
+
+This template demonstrates proper lifecycle management including:
+- Background task management in activate()/terminate()
+- Async HTTP session handling
+- Persistent data saving on shutdown
+
+Copy this file as a starting point for your own plugin.
+"""
+
+import asyncio
+from typing import Optional
+
+import aiohttp
+from astrbot.api import logger
+from astrbot.api.event import AstrMessageEvent, filter
+from astrbot.api.star import Context, Star, register
+
+
+@register(
+    "my_awesome_plugin",
+    "YourName",
+    "A short description of your plugin",
+    "1.0.0",
+    "https://github.com/YourName/astrbot_plugin_my_awesome_plugin",
+)
+class MyPlugin(Star):
+    def __init__(self, context: Context, config: dict = None):
+        super().__init__(context)
+        self.config = config or {}
+        self._cleanup_task: Optional[asyncio.Task] = None
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def activate(self):
+        """Called when the plugin is activated.
+
+        Use this to start background tasks, open connections,
+        or initialize resources that must persist across handlers.
+        """
+        logger.info("MyPlugin activated")
+        self._session = aiohttp.ClientSession()
+        self._cleanup_task = asyncio.create_task(self._periodic_cleanup())
+
+    async def terminate(self):
+        """Called when the plugin is unloaded/stopped.
+
+        MUST clean up ALL resources to prevent memory leaks:
+        1. Cancel background tasks
+        2. Close network sessions
+        3. Save persistent data
+        """
+        logger.info("MyPlugin terminating, cleaning up resources...")
+
+        # 1. Cancel background tasks
+        if self._cleanup_task and not self._cleanup_task.done():
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.error(f"Error during cleanup task cancellation: {e}")
+
+        # 2. Close HTTP session
+        if self._session and not self._session.closed:
+            await self._session.close()
+
+        # 3. Save persistent data
+        await self._save_data()
+
+        logger.info("MyPlugin terminated successfully")
+
+    async def _periodic_cleanup(self):
+        """Example background task: runs every 30 minutes."""
+        try:
+            while True:
+                await asyncio.sleep(1800)
+                # Perform periodic cleanup logic here
+                logger.debug("Periodic cleanup tick")
+        except asyncio.CancelledError:
+            logger.debug("Periodic cleanup task cancelled")
+            raise
+
+    async def _save_data(self):
+        """Example: save plugin state before shutdown."""
+        data_dir = self.context.get_data_dir()
+        # Save any persistent state here
+        logger.info(f"Plugin data directory: {data_dir}")
+
+    @filter.command("hello")
+    async def hello(self, event: AstrMessageEvent):
+        """Say hello to demonstrate basic command handling."""
+        yield event.plain_result("Hello from MyPlugin! The lifecycle template is working.")


### PR DESCRIPTION
## Summary

Add a complete lifecycle management template (`templates/plugin/main.py`) and introduce async I/O best practices to the existing best practices doc.

## Changes

### skill-astrbot-dev/design_standards/best_practices.md
- **Section 4 (Resource Cleanup)**: Simplified to a one-line guidance pointing to `templates/plugin/main.py`
- **New Section 5 (Async I/O & Thread Pool)**: Describes the difference between async and sync operations, with do/don't examples for aiohttp vs requests, and a thread pool fallback pattern

### templates/plugin/main.py (new file)
A full-featured plugin lifecycle template demonstrating:
- `activate()` / `terminate()` lifecycle hooks
- Background task management with proper cancellation
- `aiohttp.ClientSession` management
- Persistent data saving on shutdown
- Complete `@register` decorator with all required fields
- Logging integration throughout

## Notes
- `plugin-development-workflow.md` is left unchanged (v4 baseline)
- All new content is in English to avoid encoding issues
- The template is designed as a drop-in starting point for new plugins