### PR TITLE
fix: 修复文档错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 _✨ 结构化技术文档 + AGENT SKILL 定义，赋能 AI 辅助开发 ✨_
 
-[![GitHub Stars](https://img.shields.io/github/stars/EterUltimate/AstrBot-Skill?style=for-the-badge&logo=github&color=yellow)](https://github.com/EterUltimate/AstrBot-Skill)
-[![GitHub Forks](https://img.shields.io/github/forks/EterUltimate/AstrBot-Skill?style=for-the-badge&logo=github&color=blue)](https://github.com/EterUltimate/AstrBot-Skill/fork)
+[![GitHub Stars](https://img.shields.io/github/stars/EterUltimate/AstrBot-Skill?style=for-the-badge&logo=github&color=yellow)](https://github.com/xunxiing/AstrBot-Skill)
+[![GitHub Forks](https://img.shields.io/github/forks/EterUltimate/AstrBot-Skill?style=for-the-badge&logo=github&color=blue)](https://github.com/xunxiing/AstrBot-Skill/fork)
 [![QQ群](https://img.shields.io/badge/QQ群-1054962131-pink?style=for-the-badge&logo=tencent-qq&logoColor=white)](https://qm.qq.com/q/AstrBot)
 
 </div>

--- a/skill-astrbot-dev/agent/cron.md
+++ b/skill-astrbot-dev/agent/cron.md
@@ -18,7 +18,6 @@ await cron_mgr.add_basic_job(
     payload={"key": "value"},
     persistent=False,
     description="任务描述",
-    handler_params={"extra": "data"},
     enabled=True,
 )
 ```
@@ -29,7 +28,6 @@ await cron_mgr.add_basic_job(
 - `payload: dict`: 传给 handler 的上下文数据
 - `persistent: bool`: 是否持久化（重启后保留，依赖 DB）
 - `description: str`: 任务描述（v4.22.2 新增）
-- `handler_params: dict`: 额外参数，合并到 payload（v4.22.2 新增）
 - `enabled: bool`: 是否启用（v4.22.2 新增）
 
 ## 注册 AI 唤醒（Active Agent Job）

--- a/skill-astrbot-dev/agent/persona-control.md
+++ b/skill-astrbot-dev/agent/persona-control.md
@@ -33,7 +33,7 @@ await pm.create_persona(
 
 ### 3. 更新
 * **`update_persona(persona_id, system_prompt=None, begin_dialogs=None, tools=None, skills=None) -> Persona`**
-  * 注意：无 `folder_id` 与 `sort_order` 参数。若仅改 prompt，需先读旧值回填 tools/skills，避免被重置为默认。
+  * 注意：无 `folder_id` 与 `sort_order` 参数。不传 `tools`/`skills` 时这两个字段不会被修改（`NOT_GIVEN` 哨兵）。
   * 异常：ID 不存在抛 `ValueError`
 
 ```python

--- a/skill-astrbot-dev/agent/register tools.md
+++ b/skill-astrbot-dev/agent/register tools.md
@@ -1,4 +1,4 @@
-﻿---
+---
 category: agent
 ---
 
@@ -13,7 +13,7 @@ Tool 是让大语言模型调用外部能力（检索、计算、执行命令、
 
 ## 方式一：类定义 Tool（推荐，v4.5.7+）
 
-`python
+```python
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 
@@ -45,32 +45,32 @@ class BilibiliTool(FunctionTool[AstrAgentContext]):
         **kwargs,
     ) -> ToolExecResult:
         return ToolExecResult(result="搜索结果...")
-`
+```
 
 **ToolExecResult 返回值格式（v4.22.2）：**
 
-`python
+```python
 from astrbot.core.agent.tool import ToolExecResult
 
 return ToolExecResult(result="文本结果")
 return ToolExecResult(is_error=True, result="错误信息")
 return ToolExecResult(result="", image_url="https://...")  # 图片结果
-`
+```
 
 ## 注册到全局工具池
 
-`python
+```python
 class MyPlugin(Star):
     def __init__(self, context: Context):
         super().__init__(context)
         self.context.add_llm_tools(BilibiliTool())
-`
+```
 
 注册后主对话模型自动感知并调用该 Tool。
 
 ## 方式二：装饰器（兼容旧版）
 
-`python
+```python
 from astrbot.api.event import filter, AstrMessageEvent
 
 @filter.llm_tool(name="get_weather")
@@ -82,18 +82,18 @@ async def get_weather(self, event: AstrMessageEvent, location: str):
     """
     resp = self.get_weather_from_api(location)
     yield event.plain_result("天气信息: " + resp)
-`
+```
 
 Docstring 中 Args 格式必须是 参数名(类型): 描述。
 
-支持的类型：string、
-umber、object、oolean、rray、rray[string]（v4.5.7+）。
+支持的类型：string、number、object、array、boolean。
+数组元素类型写法：array[string]（v4.5.7+）。
 
 ## 内部 Tool（不注册全局）
 
 仅在单次 	ool_loop_agent 调用中可见，不进入全局工具池：
 
-`python
+```python
 from astrbot.core.agent.tool import ToolSet
 
 llm_resp = await self.context.tool_loop_agent(
@@ -102,7 +102,7 @@ llm_resp = await self.context.tool_loop_agent(
     prompt="请调用 bilibili_videos 工具搜索 AstrBot 教程",
     tools=ToolSet([BilibiliTool()]),
 )
-`
+```
 
 ## Tips
 

--- a/skill-astrbot-dev/design_standards/core_concepts.md
+++ b/skill-astrbot-dev/design_standards/core_concepts.md
@@ -48,7 +48,7 @@ prov_id = await self.context.get_current_chat_provider_id(umo)
 
 - `await context.get_current_chat_provider_id(umo) -> str`: 获取当前会话使用的 chat provider ID。
 - `await context.llm_generate(chat_provider_id, prompt, contexts=None, system_prompt=None, tools=None) -> LLMResponse`: 简化的 LLM 调用。
-- `await context.tool_loop_agent(event, chat_provider_id, prompt, tools, system_prompt=None, max_steps=30, tool_call_timeout=60) -> LLMResponse`: 工具循环 Agent。
+- `await context.tool_loop_agent(event, chat_provider_id, prompt, tools, system_prompt=None, max_steps=30, tool_call_timeout=120) -> LLMResponse`: 工具循环 Agent。
 
 **MessageChain (消息链构建器)**
 
@@ -61,7 +61,7 @@ prov_id = await self.context.get_current_chat_provider_id(umo)
 - `await self.get_kv_data(key, default)`: 获取插件隔离的 KV 数据。
 - `await self.put_kv_data(key, value)`: 存储插件隔离的 KV 数据。
 - `await self.delete_kv_data(key)`: 删除 KV 数据。
-- `await self.html_render(html_text=None, url=None, data=None, options=None)`: 将 HTML 字符串或网页渲染为图片。基于 Playwright。
+- `await self.html_render(tmpl: str, data: dict, return_url=True, options=None) -> str`: 渲染 Jinja2 HTML 模板为图片路径或 URL。基于 Playwright。
 - `text_to_image(text)`: 将文字转为图片。
 
 ### 5. 系统钩子 (Hooks)

--- a/skill-astrbot-dev/messages/model.md
+++ b/skill-astrbot-dev/messages/model.md
@@ -16,7 +16,8 @@ class AstrBotMessage:
     self_id: str          # 机器人 ID
     session_id: str       # 会话 ID，决定了上下文隔离
     message_id: str       # 消息 ID
-    group_id: str         # 群组 ID（如果是私聊则为空）
+    group: Group | None   # 群组信息（私聊为 None）
+    # group_id 是向后兼容的 @property，私聊返回空字符串
     sender: MessageMember # 发送者信息（含 user_id 和 nickname）
     message: List[BaseMessageComponent] # 消息链（组件列表）
     message_str: str      # 纯文本汇总内容

--- a/skill-astrbot-dev/plugin-development-workflow.md
+++ b/skill-astrbot-dev/plugin-development-workflow.md
@@ -1,4 +1,4 @@
-﻿# Plugin Development Workflow
+# Plugin Development Workflow
 
 ## 1. Scaffold or Inspect
 
@@ -62,7 +62,7 @@ Rules:
 Common filters:
 - `@filter.command("name")` for slash-style commands.
 - `@filter.command_group("group")` then `@group.command("sub")` for grouped commands.
-- `@filter.on_full_match(...)`, `@filter.on_prefix(...)`, `@filter.on_keyword(...)`, `@filter.on_regex(...)` for text triggers.
+- `@filter.regex(pattern)` for regex text triggers.
 - `@filter.event_message_type(...)` to restrict private/group/all message types.
 - `@filter.permission_type(...)` for permission-gated non-tool handlers.
 


### PR DESCRIPTION
### README.md
- Stars/Forks 徽章图片 URL 更正

### register tools.md
- 修复 5 个代码块，单反引号改为三反引号
- 修复类型列表乱码：`boolean`、`array`、`number` 首字母因控制字符（`\x08`、`\x07`、`\x0a`）丢失
- `array[string]` 不是独立类型，源码 `SUPPORTED_TYPES` 仅含5种基础类型，`array[string]` 在 `register_llm_tool` 解析时被正则拆分为主类型 `array` 与子类型 `string` 分别校验，从类型列表移出，改为单独语法说明

### cron.md
- 删除 `add_basic_job` 中不存在的参数 `handler_params`，源码 `astrbot/core/cron/manager.py` 签名中无此参数

### persona-control.md
- 原文"若仅改 prompt，需先读旧值回填 tools/skills"有误
- 源码 `persona_mgr.py` 中 `tools`/`skills` 默认值为 `NOT_GIVEN` 哨兵，不传时不会修改原值，无需先读后写

### core_concepts.md
- `html_render` 参数名 `html_text`/`url` 不存在，源码 `base.py` 实际签名为 `html_render(tmpl: str, data: dict, return_url=True, options=None)`
- `tool_call_timeout` 默认值由 `60` 更正为 `120`，源码 `context.py`：`tool_call_timeout: int = 120`

### messages/model.md
- `group_id` 不是直接字段，源码 `astrbot_message.py` 实际字段为 `group: Group | None`，`group_id` 是向后兼容的 `@property`

### plugin-development-workflow.md
- 删除不存在的 `@filter.on_full_match`、`@filter.on_prefix`、`@filter.on_keyword`、`@filter.on_regex`，源码 `star_handler.py` 中均无对应注册函数，正确用法为 `@filter.regex(pattern)`