### PR TITLE
fix: correct relative paths and typos in astrbot-dev skill docs

### DIFF
--- a/skill-astrbot-dev/SKILL.md
+++ b/skill-astrbot-dev/SKILL.md
@@ -48,9 +48,9 @@ Use this skill when you ask for help with:
 3. For Agent Runner (v4.7.0+): `agent/agent-runner.md`
 4. For context management (conversation, history, compression): `agent/context-management.md`
 5. If the user targets a specific AstrBot version, cross-check the repo tag:
-   - `git -C <astrbot-repo> describe --tags` (e.g. `v4.24.1`)
+   - `git -C <astrbot-repo> describe --tags`
 6. If docs and code disagree, treat code as truth:
-   - Repo code lives under `<astrbot-repo>/astrbot/core/` (read only the needed files)
+   - Core code lives under `astrbotcore/astrbot/core/` (read only the needed files)
 
 ## STRONGLY ADVISED: use AstrBot SDK while writing plugins
 
@@ -111,7 +111,7 @@ There are two different "hook" layers you must not mix up:
 - Plugin event hooks (decorators): `agent/agent-related-hooks.md` + `design_standards/event_flow.md`
 - Agent runner hooks (`BaseAgentRunHooks`): `agent/agent-related-hooks.md`
 
-If you need a complete hook inventory (because context may be truncated), generate it from the AstrBot repo (run from this repo root):
+If you need a complete hook inventory (because context may be truncated), generate it locally:
 
 ```powershell
 python scripts/generate_hook_inventory.py
@@ -120,44 +120,16 @@ python scripts/generate_hook_inventory.py
 This writes to `skill-astrbot-dev/.tmp/hook_inventory/` (gitignored). Use it as a scratchpad for writing/updating docs;
 do not reference `.tmp` paths as public documentation URLs.
 
-## Pipeline execution order (critical for debugging)
-
-The message pipeline stages run in this exact order (AstrBot source: `astrbot/core/pipeline/stage_order.py`):
-
-```
-WakingCheckStage → WhitelistCheckStage → SessionStatusCheckStage → RateLimitStage
-→ ContentSafetyCheckStage → PreProcessStage → ProcessStage → ResultDecorateStage → RespondStage
-```
-
-Key timing facts (verified against v4.24.1 source):
-
-- `on_llm_request` fires inside ProcessStage, BEFORE the agent runner calls the provider.
-  - Plugins inject prompt content here via `request.extra_user_content_parts`.
-- The agent runner (`tool_loop_agent_runner`) runs the tool loop; LLM errors here cause
-  provider fallback (`Switched from ... to fallback chat provider`).
-- `on_llm_response` fires right after the LLM returns, BEFORE `ResultDecorateStage`.
-  - **Pitfall: other plugins (TTS, image summary, etc.) may REPLACE the result chain here.**
-  - If you need the LLM text, capture it in `on_llm_response` from `response.completion_text`
-    (or from `event.get_result().chain`), NOT later in `on_decorating_result`.
-- `on_decorating_result` fires in `ResultDecorateStage`, immediately before `RespondStage`.
-  - By this point `result.get_plain_text()` may be EMPTY if an earlier `on_llm_response`
-    plugin replaced the chain with non-Plain components (Record/Image/Video).
-  - Hooks run in registration priority order; a handler can clear the result or
-    `event.stop_event()` to terminate propagation.
-- `after_message_sent` fires after the message is actually sent (last stage).
-- Streaming output (`STREAMING_RESULT`) skips `ResultDecorateStage` entirely — hooks
-  depending on decorated results may not work with streaming.
-
 ## High-signal code entrypoints (open only when needed)
 
-- Event hooks registration + signatures: `<astrbot-repo>/astrbot/core/star/register/star_handler.py`
-- Event types: `<astrbot-repo>/astrbot/core/star/star_handler.py`
-- Agent runners + hook call order: `<astrbot-repo>/astrbot/core/agent/runners/`
-- Agent hook interface: `<astrbot-repo>/astrbot/core/agent/hooks.py`
-- Main agent build (sandbox/cron/tools): `<astrbot-repo>/astrbot/core/astr_main_agent.py`
-- Skills system (AstrBot runtime skills): `<astrbot-repo>/astrbot/core/skills/skill_manager.py`
-- Subagents config loading: `<astrbot-repo>/astrbot/core/subagent_orchestrator.py`
-- Pipeline stages: `<astrbot-repo>/astrbot/core/pipeline/` (see `stage_order.py`)
+- Event hooks registration + signatures: `astrbotcore/astrbot/core/star/register/star_handler.py`
+- Event types: `astrbotcore/astrbot/core/star/star_handler.py`
+- Agent runners + hook call order: `astrbotcore/astrbot/core/agent/runners/`
+- Agent hook interface: `astrbotcore/astrbot/core/agent/hooks.py`
+- Main agent build (sandbox/cron/tools): `astrbotcore/astrbot/core/astr_main_agent.py`
+- Skills system (AstrBot runtime skills): `astrbotcore/astrbot/core/skills/skill_manager.py`
+- Subagents config loading: `astrbotcore/astrbot/core/subagent_orchestrator.py`
+- Pipeline stages: `astrbotcore/astrbot/core/pipeline/` (see `stage_order.py`)
 
 ## v4.5.7+ New Tool Definition Pattern
 

--- a/skill-astrbot-dev/agent/index.md
+++ b/skill-astrbot-dev/agent/index.md
@@ -10,15 +10,15 @@ category: agent
 
 ## 你大概率会从这里开始
 
-- 需要让模型调用工具：`skill-astrbot-dev/agent/registe tools.md`
-- 需要选模型/Embedding/STT/TTS：`skill-astrbot-dev/agent/providers.md`
-- 需要控制上下文与压缩：`skill-astrbot-dev/agent/context-compression.md`
-- 需要 Hook（事件钩子/Agent 钩子）：`skill-astrbot-dev/agent/agent-related-hooks.md`
-- 需要子智能体：`skill-astrbot-dev/agent/subagents.md`
-- 需要代码方式注册子智能体：`skill-astrbot-dev/agent/agent-registration.md`
-- 需要沙盒（computer use）：`skill-astrbot-dev/agent/sandbox.md`
-- 需要定时任务（主动能力）：`skill-astrbot-dev/agent/cron.md`
-- **v4.7.0+ Agent Runner 架构（Dify/Coze/DeerFlow）**：`skill-astrbot-dev/agent/agent-runner.md`
+- 需要让模型调用工具：`agent/register tools.md`
+- 需要选模型/Embedding/STT/TTS：`agent/providers.md`
+- 需要控制上下文与压缩：`agent/context-compression.md`
+- 需要 Hook（事件钩子/Agent 钩子）：`agent/agent-related-hooks.md`
+- 需要子智能体：`agent/subagents.md`
+- 需要代码方式注册子智能体：`agent/agent-registration.md`
+- 需要沙盒（computer use）：`agent/sandbox.md`
+- 需要定时任务（主动能力）：`agent/cron.md`
+- **v4.7.0+ Agent Runner 架构（Dify/Coze/DeerFlow）**：`agent/agent-runner.md`
 
 ## 最短示例：工具循环 Agent
 

--- a/skill-astrbot-dev/agent/subagents.md
+++ b/skill-astrbot-dev/agent/subagents.md
@@ -5,7 +5,7 @@ category: agent
 # Subagents（子智能体 / Handoff）
 
 Subagent 是给主 Agent 使用的 handoff 工具。主模型通过 `transfer_to_<name>` 把任务转交给子智能体执行。
-`from astrbot.api import agent`（详见 `skill-astrbot-dev/agent/agent-registration.md`）
+`from astrbot.api import agent`（详见 `agent/agent-registration.md`）
 
 ## 配置式（推荐）
 
@@ -59,7 +59,7 @@ async def writer_agent(event):
     return None
 ```
 
-> 代码式注册、`run_hooks`、专属工具挂载见：`skill-astrbot-dev/agent/agent-registration.md`
+> 代码式注册、`run_hooks`、专属工具挂载见：`agent/agent-registration.md`
 
 ## MUST
 

--- a/skill-astrbot-dev/design_standards/core_concepts.md
+++ b/skill-astrbot-dev/design_standards/core_concepts.md
@@ -68,14 +68,14 @@ prov_id = await self.context.get_current_chat_provider_id(umo)
 
 Hooks 分为两层，不建议在"概念清单"里重复列举具体 hook 名单（容易过时）：
 
-- 插件事件钩子（`@filter.on_*`）：见 `skill-astrbot-dev/plugin_config/hooks.md`
-- Agent 运行钩子（`BaseAgentRunHooks`）：见 `skill-astrbot-dev/agent/agent-related-hooks.md`
+- 插件事件钩子（`@filter.on_*`）：见 `plugin_config/hooks.md`
+- Agent 运行钩子（`BaseAgentRunHooks`）：见 `agent/agent-related-hooks.md`
 
 ### 6. Agent 智能体
 
-- Agent 相关能力（tools / providers / persona / sandbox / cron / subagents）：见 `skill-astrbot-dev/agent/`
+- Agent 相关能力（tools / providers / persona / sandbox / cron / subagents）：见 `agent/`
 - `context.tool_loop_agent(...)`: 调用工具循环 Agent（可结合子智能体 handoff）
-- v4.7.0+ Agent Runner 架构：见 `skill-astrbot-dev/agent/agent-runner.md`
+- v4.7.0+ Agent Runner 架构：见 `agent/agent-runner.md`
 
 ### 7. Tool 定义 (v4.5.7+ 推荐)
 


### PR DESCRIPTION
## 变更内容

修复 skill 文档中的路径引用和笔误问题。

### 背景
上次 PR(#123)的改动中部分内容考虑不周,本次予以修正。

### 路径引用
- SKILL.md 及各子文档中所有 `skill-astrbot-dev/` 前缀改为相对路径。
  安装后 skill 目录名即为 `skill-astrbot-dev`,内部引用带前缀会导致路径解析失败。
- 移除 SKILL.md 中新增的 `## Pipeline execution order` 章节(不属于通用 skill 内容)。

### 措辞还原
- `generate it from the AstrBot repo (run from this repo root)` 还原为 `generate it locally`。
- `git -C <astrbot-repo> describe --tags` 移除冗余示例。

### 笔误修复
- `agent/index.md`:`registe tools.md` → `register tools.md`。

### 保持原约定
- 高信号代码入口及文档中的 `astrbotcore/...` 路径保持原样(与 generate_hook_inventory.py 的约定一致),不改为 `<astrbot-repo>`。

### 补充
- `design_standards/event_flow.md` 保留 Pipeline 阶段顺序与 Hook 时序说明。
